### PR TITLE
Correct argument type

### DIFF
--- a/src/Pandoc.jl
+++ b/src/Pandoc.jl
@@ -245,7 +245,7 @@ mutable struct Document
     blocks::Vector{Element}
 
     function Document(data)
-        pandoc_api_version = VersionNumber(data["pandoc-api-version"][1:end-1]..., (data["pandoc-api-version"][end],))
+        pandoc_api_version = VersionNumber(data["pandoc-api-version"][1:end-1]..., data["pandoc-api-version"][end])
         meta = data["meta"]
         blocks = get_elements(data["blocks"])
         return new(data, pandoc_api_version, meta, blocks)


### PR DESCRIPTION
I got this error when running the example from [Presentation.jl](https://github.com/kdheepak/Presentation.jl), so I edited the last argument in source code so that it type matches a method.

Again, I don't know the internals of this package, so please do review the PR carefully.

```julia
julia> render("examples/slides.md")
ERROR: MethodError: no method matching VersionNumber(::Int64, ::Int64, ::Tuple{Int64})
Closest candidates are:
  VersionNumber(::Integer, ::Integer) at version.jl:61
  VersionNumber(::Integer, ::Integer, ::Integer) at version.jl:61
  VersionNumber(::Integer, ::Integer, ::Integer, ::Tuple{Vararg{Union{AbstractString, Integer},N} where N}) at version.jl:61
  ...
Stacktrace:
 [1] Pandoc.Document(::Dict{String,Any}) at /home/hung/.julia/packages/Pandoc/ikAfa/src/Pandoc.jl:248
 [2] run_pandoc(::String) at /home/hung/.julia/packages/Pandoc/ikAfa/src/Pandoc.jl:610
 [3] read at /home/hung/.julia/dev/Presentation/src/slideshow.jl:37 [inlined]
 [4] render at /home/hung/.julia/dev/Presentation/src/renderer.jl:280 [inlined]
 [5] render(::String) at /home/hung/.julia/dev/Presentation/src/renderer.jl:259
 [6] top-level scope at REPL[14]:1
 [7] run_backend(::REPL.REPLBackend) at /home/hung/.julia/packages/Revise/cbX7Q/src/Revise.jl:973
 [8] (::getfield(Revise, Symbol("##79#81")){REPL.REPLBackend})() at ./task.jl:268
```