### PR TITLE
Basic functionality such as `elementsbytype` using `AbstractTrees`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Dheepak Krishnamurthy <me@kdheepak.com>"]
 version = "0.4.4"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"

--- a/src/Pandoc.jl
+++ b/src/Pandoc.jl
@@ -19,6 +19,7 @@ using InlineTest
 using JSON3
 using StructTypes
 using DataStructures
+using AbstractTrees
 
 using pandoc_jll
 
@@ -26,5 +27,6 @@ const PANDOC_JL_EXECUTABLE = get(ENV, "PANDOC_JL_EXECUTABLE", pandoc())
 
 include("types.jl")
 include("interface.jl")
+include("nodes.jl")
 
 end # module

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -110,8 +110,8 @@ Base.getproperty(n::PandocStructNode, s::Symbol) = begin
         return isa(prop, _PandocAll) ? PandocNode(prop, n, s) : prop
     end
 end
-Base.setproperty!(n::PandocStructNode, s, v) = setproperty!(nodevalue(n), s, v)
-Base.setproperty!(n::PandocStructNode, s, v::PandocNode) = setproperty!(nodevalue(n), s, nodevalue(v))
+Base.setproperty!(n::PandocStructNode, s::Symbol, v) = setproperty!(nodevalue(n), s, v)
+Base.setproperty!(n::PandocStructNode, s::Symbol, v::PandocNode) = setproperty!(nodevalue(n), s, nodevalue(v))
 Base.getindex(n::PandocVectorNode, idx) = PandocNode(getindex(nodevalue(n), idx), n, idx)
 Base.setindex!(n::PandocVectorNode, v, idx) = setindex!(nodevalue(n), v, idx)
 Base.setindex!(n::PandocVectorNode, v::PandocNode, idx) = setindex!(nodevalue(n), nodevalue(v), idx)

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -1,0 +1,180 @@
+const PandocType = Union{
+    Attr,
+    Caption,
+    Cell,
+    ColSpec, # 
+    ColWidth, #
+    Citation,
+    ListAttributes, #
+    Row,
+    ShortCaption,
+    TableBody,
+    TableFoot,
+    TableHead,
+    Target, #
+    Element,
+    Pair{Vector{Inline}, Vector{Vector{Block}}},
+}
+
+Base.getindex(el::PandocType, prop::Symbol) = getproperty(el, prop)
+Base.setindex!(el::PandocType, x, prop::Symbol) = setproperty!(el, prop, x)
+Base.getindex(doc::Pandoc.Document, idx) = doc.blocks[idx]
+Base.setindex!(doc::Pandoc.Document, x, idx) = setindex!(doc, x, idx)
+
+const Key = Union{Int, Symbol}
+
+"""
+
+    rootnode = PDNode(root)
+
+It returns a Node elements from which navigate the document.
+"""
+mutable struct PDNode{N,P,K}
+    node::N
+    parent::Union{Nothing, PDNode}
+    key::Key
+    function PDNode(n, p, k)
+        new{typeof(n), typeof(nodevalue(p)), isa(n, Vector) ? Int : Symbol}(n, p, k)
+    end
+    function PDNode(n::Pandoc.Document, p, k)
+        new{typeof(n), typeof(nodevalue(p)), Int}(n, p, k)
+    end
+end
+PDNode(root) = PDNode(root, nothing, 1)
+
+const PDNodeSymbol = PDNode{N,P,Symbol} where {N,P}
+const PDNodeInt = PDNode{N,P,Int} where {N,P}
+
+AbstractTrees.nodevalue(n::PDNode) = n.node
+AbstractTrees.nodevaluetype(n::PDNode{N,P,K}) where {N,P,K} = N
+AbstractTrees.children(n::PDNodeInt) = begin
+    ch = PDNode[]
+    nv = nodevalue(n)
+    for i in eachindex(nv)
+        push!(ch, PDNode(nv[i], n, i))
+    end
+    ch
+end
+AbstractTrees.children(n::PDNode{Pandoc.Document,Nothing,Int}) = begin
+    ch = PDNode[]
+    nv = nodevalue(n).blocks
+    for i in eachindex(nv)
+        push!(ch, PDNode(nv[i], n, i))
+    end
+    ch
+end
+AbstractTrees.children(n::PDNodeSymbol) = begin
+    ch = PDNode[]
+    nv = nodevalue(n)
+    for prop in propertynames(nv)
+        push!(ch, PDNode(nv[prop], n, prop))
+    end
+    ch
+end
+AbstractTrees.parent(n::PDNode) = n.parent
+AbstractTrees.ParentLinks(::Type{<:PDNode}) = StoredParents()
+AbstractTrees.printnode(io::IO, n::PDNode) = begin
+    if isnothing(n.parent)
+        print(io, "<", typeof(n).parameters[1], " ROOT>")
+    else
+        print(io, "<", typeof(n).parameters[1], " <= ", typeof(n).parameters[2], "[", isa(n.key, Int) ? "" : ":", n.key, "]>")
+    end
+end
+Base.show(io::IO, n::PDNode) = begin
+    if isnothing(n.parent)
+        print(io, "<", typeof(n).parameters[1], " ROOT>")
+    else
+        print(io, "<", typeof(n).parameters[1], " <= ", typeof(n).parameters[2], "[", isa(n.key, Int) ? "" : ":", n.key, "]>")
+    end
+end
+
+
+"""
+    clone(el)
+
+Clone element as deatached from parent. 
+"""
+function clone(el::TreeCursor) end
+"""
+    collectall(root)
+
+Colects all elements in `root`, including those which are not Pandoc types. It returns a collection of `IndexedCursor`s
+"""
+function collectall(root::PDNode) 
+    collect(PostOrderDFS(root))
+end
+
+"""
+
+    elementsbytype(rootnode, type)
+
+Returns all `PDNode{N,P,K}` which types `N <: type`.
+"""
+function elementsbytype(root::PDNode{N,Nothing,K}, type::Type{<:PandocType}) where {N,K}
+    o = PDNode[]
+    itr = PostOrderDFS(root)
+    for i in itr
+        if AbstractTrees.nodevaluetype(i) == type
+            push!(o, i)
+        end
+    end
+    o
+end
+
+function hasclass(n::PDNode{Attr,P,Symbol}, class::String) where P
+    nv = nodevalue(n)
+    if in(:classes, propertynames(nv)) 
+        return in(class, nv.classes)
+    else
+        return false
+    end
+end
+
+function elementsbyclass(root::PDNode, class::String) 
+    itr = elementsbytype(root, Attr)
+    map(AbstractTrees.parent, filter((el) -> hasclass(el, class) , itr))
+end
+
+"""
+    elementbyid(root, id)
+
+Returns first Pandoc element which `el.attr.identifier` equals `id`. Returns a IndexedCursor from which 
+one can navigate the document.
+"""
+function elementbyid(root::PDNode, id::String)
+    itr = PostOrderDFS(root)
+    for i in itr
+        if AbstractTrees.nodevaluetype(i) == Attr && nodevalue(i).identifier == id
+            return AbstractTrees.parent(i)
+        end
+    end
+    o
+end
+
+# |||| WIP This is work in progreess. ||||
+# vvvv                                vvvv
+
+function remove!(el::AbstractTrees.IndexedCursor{<:PandocType,Vector}) 
+    
+end
+function addafter!(el::AbstractTrees.IndexedCursor{<:PandocType,Vector}, new) 
+    
+end
+function addbefore!(el::AbstractTrees.IndexedCursor{<:PandocType,Vector}, new) 
+    
+end
+
+# Methods that act over all nodes
+function clear!(crs::AbstractTrees.IndexedCursor{<:PandocType, <:PandocType})
+    p = AbstractTrees.parent(crs)
+    idx = crs.index
+    props = propertynames(nodevalue(p))
+    el = typeof(nodevalue(crs))()
+    setproperty!(nodevalue(p), props[idx], el)
+end
+
+function substitute!(el, new) 
+    # el and new must be similar
+    p = (nodevalue ∘ parent)(el)
+    setproperty!(nodevalue(p), el.key, new)
+end

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -203,7 +203,7 @@ function clear!(n::PandocNode)
     else
         deleteat!(pv, n.key)
     end
-    nothing
+    n
 end
 """ 
     substitute!(n, new)
@@ -217,7 +217,7 @@ function substitute!(n::PandocNode, new)
     else
         setindex!(pv, new, n.key)
     end
-    nothing
+    n
 end
 """ 
     addafter!(n, new)
@@ -226,9 +226,9 @@ Adds the element `new` after the node `n`.
 """
 function addafter!(n::PandocNode, new) 
     isa(n.key, Symbol) && error("Cannot add a new element if parent is not a vector!")
-    pv = nodevalue(parent(n))
-    splice!(pv, n.key, [n.node, new])
-    nothing
+    p = parent(n)
+    splice!(nodevalue(p), n.key, [n.node, new])
+    PandocNode(new, p, n.key + 1)
 end
 """ 
     addbefore!(n, new)
@@ -239,7 +239,7 @@ function addbefore!(n::PandocNode, new)
     isa(n.key, Symbol) && error("Cannot add a new element if parent is not a vector!")
     pv = nodevalue(parent(n))
     splice!(pv, n.key, [new, n.node])
-    nothing
+    PandocNode(new, p, n.key)
 end
 """
     hasclass(n, class)
@@ -259,7 +259,7 @@ function addclass!(n::PandocNode{<:_PandocWithAttr}, class)
     classes = nodevalue(n).attr.classes
     in(class, classes) && return nothing
     push!(classes, class)
-    nothing
+    n
 end
 """
     removeclass!(n, class)
@@ -269,7 +269,7 @@ Removes all classes `class` from `n`.
 function removeclass!(n::PandocNode{<:_PandocWithAttr}, class)
     classes = nodevalue(n).attr.classes
     filter!((c) -> !isequal(c,class), classes)
-    nothing
+    n
 end
 """
     getattr(n, attr_name)
@@ -294,7 +294,7 @@ function addattr!(n::PandocNode{<:_PandocWithAttr}, attr::Tuple{String, String})
         a[1] == attr[1] && error("Attribute already in use. Try to remove it first with `removeattr!`.")
     end
     push!(attrs, attr)
-    nothing
+    n
 end
 """
     removeattr!(n, attr_name)
@@ -304,5 +304,5 @@ Removes the value of the attribute `attr_name` for the node `n`, if any.
 function removeattr!(n::PandocNode{<:_PandocWithAttr}, attr_name::String)
     attrs = nodevalue(n).attr.attributes
     filter!((a) -> !isequal(a[1], attr_name) , attrs)
-    nothing
+    n
 end


### PR DESCRIPTION
WIP:

Using the `AbstractTrees` interface allows to define methods such `elementsbytype` or `elementsbyclass`.

This is still experimental. How does it work? One creates a root `Node` with 
```julia
julia> root = PandocNode(doc)
<Pandoc.Document ROOT>
```
The following methods are expected to work sooner than later,
* `elementsbytype(root, type)`
* `elementsbyclass(root, class)`
* `elementbyid(root, id)`
* `clear!(el)`
* `substitute!(el, new)`
* `addbefore!(el, new)`
* `addafter!(el, new)`
