### PR TITLE
fix: use `--lua-filter` pandoc flag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pandoc"
 uuid = "f853b5e0-b243-11e9-0043-7da5023c5ee7"
 authors = ["Dheepak Krishnamurthy <me@kdheepak.com>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -187,7 +187,7 @@ function command(c::Converter; p = PANDOC_JL_EXECUTABLE)
     cmd = `$cmd --filter=$(c.filter)`
   end
   for lua_filter in c.lua_filter
-    cmd = `$cmd -- $(c.lua_filter)`
+    cmd = `$cmd --lua-filter=$lua_filter`
   end
   !isnothing(c.shift_heading_level_by) && (cmd = `$cmd --shift-heading-level-by=$(c.shift_heading_level_by)`)
   !isnothing(c.base_header_level) && (cmd = `$cmd --base-header-level=$(c.base_header_level)`)


### PR DESCRIPTION
Hi!

I want to use Lua filter in order to get simplified Markdown from HTML. Now I have:
```julia-repl
julia> html = """
       <!DOCTYPE html>
       <html>
       <body>

       <h1>My First Heading</h1>

       <p>My first paragraph.</p>

       </body>
       </html>
       """

julia> c = Pandoc.Converter(
    input = html,
    from = "html",
    to = "commonmark-raw_html-footnotes",
    lua_filter = [p"./lua/simple_markdown_filter.lua"],
)
`pandoc -f html -t commonmark-raw_html-footnotes -- ./lua/simple_markdown_filter.lua`

julia> run(c)
"function Space(\\_) return pandoc.Space() end function SoftBreak(\\_)\nreturn pandoc.Space() end function LineBreak(\\_) return pandoc.Space()\nend function Strong(el) return el.content end function Emph(el) return\nel.content end function Underline(el) return el.content end function\nSmallCaps(el) return el.content end function Link(el) return el.content\nend function Image(\\_) return {} end\n"
```

So instead of returning Markdown string it returns the Lua filter content.
With my fix:
```Julia-repl
julia> c = Pandoc.Converter(
    input = html,
    from = "html",
    to = "commonmark-raw_html-footnotes",
    lua_filter = [p"./lua/simple_markdown_filter.lua"],
)
`pandoc -f html -t commonmark-raw_html-footnotes --lua-filter=./lua/simple_markdown_filter.lua`

julia> run(c)
"# My First Heading\n\nMy first paragraph.\n"
```
